### PR TITLE
v5.1.1.1 - Fix DMRG_MEASURE <Sz> <SiSj>

### DIFF
--- a/src/DMRG_MEASURE.f90
+++ b/src/DMRG_MEASURE.f90
@@ -350,7 +350,7 @@ contains
   !##################################################################
   function Build_Op_dmrg(Op,pos,set_basis) result(Oi)
     type(sparse_matrix),intent(in) :: Op
-    integer                        :: pos
+    integer                        :: pos,pos_aux
     type(sparse_matrix)            :: Oi
     logical,optional               :: set_basis   
     !
@@ -381,7 +381,10 @@ contains
     !i = M(pos)
     !recall that M: OBC: 1+2+...Ldmrg-2+Ldmrg-1+Ldmrg
     !               PBC: Ldmrg+Ldmrg-2..+1+..+Ldmrg-1
-    i=b2gMap(pos)    ; if(pos>L)i=b2gMap(N+1-pos)
+    !i=b2gMap(pos)    ; if(pos>L)i=b2gMap(N+1-pos)
+    pos_aux=pos
+    IF(pos>L)pos_aux=N+1-pos
+    i=b2gMap(pos_aux)
     !
     !Build Operator on the chain at position pos:   
     if(i==1)then
@@ -473,7 +476,7 @@ contains
   !##################################################################
   function Advance_Op_dmrg(Op,pos,nstep) result(Oi)
     type(sparse_matrix),intent(in)   :: Op
-    integer                          :: pos
+    integer                          :: pos,pos_aux
     integer,optional                 :: nstep
     type(sparse_matrix)              :: Oi,U
     character(len=1)                 :: label
@@ -496,7 +499,10 @@ contains
     label='l'; if(pos>L)label='r'
     !
     !Get index in the block from the position pos in the chain:
-    i=b2gMap(pos)    ; if(pos>L)i=b2gMap(N+1-pos)
+    !i=b2gMap(pos)    ; if(pos>L)i=b2gMap(N+1-pos)
+    pos_aux=pos
+    IF(pos>L)pos_aux=N+1-pos
+    i=b2gMap(pos_aux)
     !
     istart  = i
     select case(label)


### PR DESCRIPTION
Branch created to fix the MEASURE process for the spin problem.

- Problem observed in all cases. Infinite OBC (solved)
Infinite PBC (still under analysis)
Finite OBC (still under analysis)
Finite PBC (still under analysis)

---------------------------------------
FIX FOR THE INFINITE OBC CASE
---------------------------------------
ERROR REPORTED:
At line 384 of file $LIB_DIR/nssDMRG/src/DMRG_MEASURE.f90 Fortran runtime error: Index '#' of dimension 1 of array 'b2gmap' above upper bound of (#-1)

Important: This array reappear around line 500

---------------------------------------
FIX:
- Line 384:
	i=b2gMap(pos)    ; if(pos>L)i=b2gMap(N+1-pos)

This error appear in the Measure process for <Sz> and <SiSj> because the 'b2gMap' array is allocated with size equal to Ldmrg.
However, the 'pos' integer variable goes from 1 to 2*Ldmrg.

So, the previous construction can exceed the index for 'b2gMap' before the IF case. As a simple solution, I simply added a new integer variable, called 'pos_aux', and used the IF case to properly define the value of 'pos_aux' and use it as the index for 'b2gMap' The changes are as follow:

	INTEGER:: pos_aux
	!(...)
	pos_aux=pos
	if(pos>L)pos_aux=N+1-pos
	i=b2gMap(pos_aux)

---------------------------------------
---------------------------------------
FIX FOR THE INFINITE PBC CASE
---------------------------------------
ERROR REPORTED:
Note: The following floating-point exceptions are signalling: IEEE_DIVIDE_BY_ZERO IEEE_UNDERFLOW_FLAG IEEE_DENORMAL
 get_op_operators_list error: key not found15

This error prevents the calculation of <SiSj>.

---------------------------------------
FIX:

---------------------------------------
---------------------------------------
FIX FOR THE FINITE OBC CASE
---------------------------------------
ERROR REPORTED:
At line 387 of file $LIB_DIR/nssDMRG/src/DMRG_MEASURE.f90 Fortran runtime error: Index '17' of dimension 1 of array 'b2gmap' above upper bound of 16

This error, although it seems similar to the first case, is slightly different. It arises because in the finite case, when the system growth ends, let's say of size L, the library adds an extra dot, that is, a dot L+1, causing the b2gMap array always to be 1 site smaller than the actual size of the lattice in the finite case.

To fix this, there are 2 possibilities.

(i) Redefine the size of the b2gMap array to L+1 for the finite algorithm, taking into account the implications of this change in the operator's recovery during the measurement process.

(ii) End the growth of the finite algorithm with 1 site less (L-1), so that the extra step of adding a site to perform the finite algorithm corresponds to the actual exact size of b2gMap.

---------------------------------------
FIX:

---------------------------------------
---------------------------------------
FIX FOR THE FINITE PBC CASE
---------------------------------------
ERROR REPORTED:

---------------------------------------
FIX: